### PR TITLE
refs #8: Git branch name broken with quotes on subject (actually a ut…

### DIFF
--- a/src/Sparkfabrik/Command/Redmine/RedmineGitBranchCommand.php
+++ b/src/Sparkfabrik/Command/Redmine/RedmineGitBranchCommand.php
@@ -86,7 +86,15 @@ EOF
         $story_name = trim($subject_items[2]);
 
         // Clean story name.
-        $story_name = str_replace(array('[', ']'), '', $story_name);
+        if (mb_detect_encoding($story_name) === 'UTF-8') {
+            $story_name_converted = @iconv('UTF-8', 'ASCII//TRANSLIT', $story_name);
+            if ($story_name_converted) {
+                $story_name = $story_name_converted;
+            } else {
+                $story_name = iconv('UTF-8', 'ASCII//IGNORE', $story_name);
+            }
+        }
+        $story_name = preg_replace("/[^a-z0-9 -]/i", '', $story_name);
         $story_name = strtolower(preg_replace("/\W/", '_', $story_name));
         $story_name = implode((array_filter(explode(' ', str_replace('_', ' ', $story_name)))), '_');
 

--- a/tests/SparkFabrik/Command/Redmine/RedmineGitBranchCommandTest.php
+++ b/tests/SparkFabrik/Command/Redmine/RedmineGitBranchCommandTest.php
@@ -30,7 +30,7 @@ class RedmineGitBranchCommandTest extends \PHPUnit_Framework_TestCase
     private $redmineClient;
     private $redmineApiIssue;
 
-    private $issue_subject = 'SP-000 - Testing branch name';
+    private $issue_subject = 'SP-000 - Testing branch name with “quoted”-utf8 and àccènted wörds';
     private $issue_subject_wrong = 'BUG: testing_branch_name';
 
     protected function setUp()
@@ -118,7 +118,11 @@ class RedmineGitBranchCommandTest extends \PHPUnit_Framework_TestCase
         );
         $this->tester->execute($input);
         $res = trim($this->tester->getDisplay());
-        $this->assertEquals('SP-000_1234_testing_branch_name', $res);
+        $this->assertContains('SP-000_1234_testing_branch_name', $res);
+        // Elimination of utf-8 punctuation.
+        $this->assertContains('quoted_utf8', $res);
+        // Transliteration of utf-8 accented characters.
+        $this->assertContains('accented_words', $res);
     }
 
     public function testCreateGitBranchWithAwrongIssueFormat()


### PR DESCRIPTION
…f8 problem)
