### PR TITLE
Redmine - Search: filter by Issue Category

### DIFF
--- a/src/Sparkfabrik/Command/Redmine/RedmineSearchCommand.php
+++ b/src/Sparkfabrik/Command/Redmine/RedmineSearchCommand.php
@@ -32,19 +32,7 @@ class RedmineSearchCommand extends RedmineCommand
         $this
             ->setName('redmine:search')
             ->setDescription('Search redmine issues')
-            ->setHelp(
-                <<<EOF
-The <info>%command.name%</info> command displays help for a given command:
-
-  <info>php %command.full_name% list</info>
-
-You can also output the help in other formats by using the <comment>--format</comment> option:
-
-  <info>php %command.full_name% --format=xml list</info>
-
-To display the list of available commands, please use the <info>list</info> command.
-EOF
-            );
+            ->setHelp('The <info>%command.name%</info> command searches isseus on redmine.');
         // Add options.
         $this->addOption(
             'report',


### PR DESCRIPTION
tnx to @paolomainardi , some tips:
- use this API http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories
- use Handler (just like users') to support id|name

Filtering issues by category simply doesn't work on Redmine API.

Tested by Postman too but Redmine issue API doesn't recognize "catagory" neither "category_id" as filter.

Postman data to reproduce: {"version":1,"collections":[{"id":"e4adca63-4773-5d18-a3f8-5e2cac041ba0","name":"redmine","timestamp":1429192373805,"requests":[{"collectionId":"e4adca63-4773-5d18-a3f8-5e2cac041ba0","id":"ce13c5c3-847b-c542-f2ce-dec8acbcde12","name":"filter issue by category (attempt)","description":"", "url":"https://projects.agavee.com/issues.json?limit=100&category_id=73", "method":"GET","headers":"X-Redmine-API-Key: PUTYOURKEYHERE\n","data":[],"dataMode":"params","timestamp":0,"responses":[],"version":2}]}],"environments":[],"headerPresets":[],"globals":[]}
