### PR TITLE
ref #ST-73 - fix to add api version and trailing slash to the gitlab url

### DIFF
--- a/src/Sparkfabrik/Services/GitlabService.php
+++ b/src/Sparkfabrik/Services/GitlabService.php
@@ -38,8 +38,13 @@ class GitlabService extends AbstractService
     protected function initClient()
     {
         if (empty($this->client)) {
+            $gitlab_url = $this->config['gitlab_url'];
+            if (substr($gitlab_url, -1) !== '/') {
+                $gitlab_url .= '/';
+            }
+            $gitlab_url .= 'api/v3/';
             $this->client = new \Gitlab\Client(
-                $this->config['gitlab_url']
+                $gitlab_url
             );
             $this->client->authenticate($this->config['gitlab_token'], \Gitlab\Client::AUTH_URL_TOKEN);
             if (empty($this->client)) {


### PR DESCRIPTION
at this moment I've added your fix (@paolomainardi) waiting to work the issue to manage the 'first configuration' dialog
